### PR TITLE
2025-12 Fix deadlocks and panics, other bugfixes and updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to GitHub and Crates.io
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+env:
+  GIT_TAG: ${{ github.ref_name }}
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.GIT_TAG }}
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Authenticate with Crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Publish to Crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ github.repository }}
+          target: env-build
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run Docker image
+        run: docker run --name temp ${{ github.repository }}
+      - name: Copy Docker container artifacts
+        run: |
+          mkdir -p bin
+          docker cp temp:/srv/luavisors-glibc-amd64 ./bin/luavisors-glibc-amd64
+          docker cp temp:/srv/SHA256SUMS ./bin/SHA256SUMS
+      - name: Upload the latest artifacts to releases
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "bin/*"
+          makeLatest: true
+          name: ${{ env.GIT_TAG }}
+          tag: ${{ env.GIT_TAG }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "luavisors"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-signal",
  "mlua",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ license = "MPL-2.0"
 
 [dependencies]
 async-signal = { version = "0.2" }
-mlua = { version = "0.11.5", features = ["luajit52", "vendored", "async", "send"] }
+mlua = { version = "0.11", features = ["luajit52", "vendored", "async", "send"] }
 smol = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luavisors"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = [ "fboulnois <fboulnois@users.noreply.github.com>" ]
 description = "A minimal process supervisor for containers using Rust and Lua"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,17 @@ FROM rust:1.82 AS env-build
 WORKDIR /srv
 COPY . /srv/
 
-# cache dependencies and objects and build binary
-RUN \
-  --mount=type=cache,id=cargo-cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo-cache,target=/srv/target \
-  cargo build --release \
-  && cp target/release/luavisors /srv/luavisors
+# build binary and calculate checksum
+RUN cargo build --release \
+  && cp target/release/luavisors /srv/luavisors-glibc-amd64 \
+  && sha256sum luavisors-glibc-amd64 > SHA256SUMS
 
 FROM gcr.io/distroless/cc:nonroot AS env-deploy
 
 # copy binary into distroless container
-COPY --from=env-build /srv/luavisors /bin/dash /bin/
-COPY lua/ /bin/
+COPY --from=env-build /srv/luavisors-glibc-amd64 /bin/luavisors
+COPY lua/ /app/
 
 USER nonroot
 
-CMD [ "luavisors", "/bin/advanced.lua" ]
+CMD [ "luavisors", "/app/advanced.lua" ]

--- a/lua/advanced.lua
+++ b/lua/advanced.lua
@@ -38,11 +38,9 @@ local function check_for_updates()
     -- launch the "updated" software
     software = exec_software()
     print('software restarted with pid', software:pid())
-    assert(software:status() == 0)
-    print('software completed')
 end
 
-init.every(5, check_for_updates)
+init.every(3, check_for_updates)
 
--- wait for software to finish
-init.sleep(10)
+-- wait for update to complete
+init.sleep(5)

--- a/lua/api.lua
+++ b/lua/api.lua
@@ -6,50 +6,47 @@ local init = require('init')
 -- Print parent process id
 print('parent pid:', init.pid())
 
--- Start a child process asynchronously
-local sleep1 = init.exec('sleep', '5')
+-- Start child process asynchronously
+local child1 = init.exec('printf', '%s', 'hello world')
 
--- Print child process id
-print('sleep pid:', sleep1:pid())
+-- print child process id
+print('child1 pid:', child1:pid())
 
--- Start another child process asynchronously
-local echo = init.exec('echo', 'hello', 'world')
-
--- Print child process output, will print before sleep finishes
-print('echo stdout:', echo:stdout())
+-- Print child process output
+print('child1 stdout:', child1:stdout())
 
 -- Check that no error occurred
-print('echo no error:', echo:stderr() == nil)
+print('child1 stderr is empty:', child1:stderr() == nil)
+
+-- Check that process exited with code 0
+print('child1 exited normally:', child1:status() == 0)
+
+-- Start a child process asynchronously
+local child2 = init.exec('sleep', 2)
 
 -- Terminate the child process directly
-sleep1:kill()
+child2:kill()
 
--- Verify that the sleep process was killed
-print('sleep1 exited with SIGKILL:', sleep1:status() == init.signal.SIGKILL)
+-- Verify that the child process was killed
+print('child2 exited with SIGKILL:', child2:status() == init.signal.SIGKILL)
 
--- Start another sleep process asynchronously
-local sleep2 = init.exec('sleep', '5')
+-- Start another child process asynchronously
+local child3 = init.exec('sleep', 2)
 
 -- Send a signal to the child process
-init.kill(sleep2:pid(), init.signal.SIGTERM)
+init.kill(child3:pid(), init.signal.SIGTERM)
 
--- Verify that the sleep process was killed
-print('sleep2 exited with SIGTERM:', sleep2:status() == init.signal.SIGTERM)
+-- Verify that the child process was killed
+print('child3 exited with SIGTERM:', child3:status() == init.signal.SIGTERM)
 
--- Start a third sleep process asynchronously
-local sleep3 = init.exec('sleep', '1')
-
--- Verify that the sleep process exited normally
-print('sleep3 exited normally:', sleep3:status() == 0)
-
--- Start an echo process asynchronously
-local function echo(...)
-    local child = init.exec('echo', ...)
-    print('echo stdout:', child:stdout())
+-- Define an asynchronous job that prints the current time and arguments
+local function job(...)
+    local child = init.exec('printf', '%s %s %s', os.date("%X"), ...)
+    print('job stdout:', child:stdout())
 end
 
--- Run the echo function every 2 seconds
-init.every(2, echo, 'hello', 'world')
+-- Run the job function every second
+init.every(1, job, 'hello', 'world')
 
--- Sleep for 5 seconds to allow the echo function to run
-init.sleep(5)
+-- Sleep for enough time to allow the job function to run multiple times
+init.sleep(3)

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,16 +9,16 @@ async fn pid(_lua: Lua, _: ()) -> LuaResult<u32> {
 }
 
 /// Sleep the Lua runtime for `n` seconds
-async fn sleep(_lua: Lua, n: u64) -> LuaResult<u64> {
-    smol::Timer::after(std::time::Duration::from_secs(n)).await;
+async fn sleep(_lua: Lua, n: f64) -> LuaResult<f64> {
+    smol::Timer::after(std::time::Duration::from_secs_f64(n)).await;
     Ok(n)
 }
 
 /// Asynchronously call a Lua function every `n` seconds
-async fn every(lua: Lua, (n, func, args): (u64, LuaFunction, LuaMultiValue)) -> LuaResult<()> {
+async fn every(lua: Lua, (n, func, args): (f64, LuaFunction, LuaMultiValue)) -> LuaResult<()> {
     let weak_lua = lua.weak();
     smol::spawn(async move {
-        let mut timer = smol::Timer::interval(std::time::Duration::from_secs(n));
+        let mut timer = smol::Timer::interval(std::time::Duration::from_secs_f64(n));
         while let Some(_instant) = timer.next().await {
             // stop task if the Lua instance has been destroyed
             let Some(_lua) = weak_lua.try_upgrade() else {
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_sleep() {
         let lua = Lua::new();
-        let n = 0;
+        let n = 0.0;
         let result = smol::block_on(sleep(lua, n));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), n);
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_every() {
         let lua = Lua::new();
-        let n = 0;
+        let n = 0.0;
         let func = lua.create_function(|_, ()| Ok(())).unwrap();
         let result = smol::block_on(every(lua, (n, func, LuaMultiValue::new())));
         assert!(result.is_ok());
@@ -87,7 +87,7 @@ mod tests {
         let lua = Lua::new();
         let globals = lua.globals();
         globals.set("count", 0).unwrap();
-        let n = 0;
+        let n = 0.0;
         let code = r#"
                 count = count + 1
                 if count == 1 then

--- a/src/init.rs
+++ b/src/init.rs
@@ -32,7 +32,7 @@ async fn every(_lua: Lua, (n, func, args): (u64, LuaFunction, LuaMultiValue)) ->
 async fn kill(_lua: Lua, (pid, sig): (i32, i32)) -> LuaResult<i32> {
     unix::kill(pid, sig)
         .await
-        .map_err(|err| LuaError::runtime(err.to_string()))
+        .map_err(|err| LuaError::runtime(err))
 }
 
 /// Return the `init` Lua module

--- a/src/process.rs
+++ b/src/process.rs
@@ -121,7 +121,7 @@ pub async fn exec(lua: Lua, (cmd, args): (String, LuaMultiValue)) -> LuaResult<L
                 let code = status
                     .signal()
                     .or_else(|| status.code())
-                    .ok_or(LuaError::runtime("failed to get status code".to_string()))?;
+                    .ok_or(LuaError::runtime("failed to get status code"))?;
                 Ok(code)
             }
         })?,


### PR DESCRIPTION
* Only pin major and minor version, not patch
* Ensure `init.every` errors are printed to stderr
* Treat table values as additional arguments to `exec`
* Simplify error message propagation
* Prevent deadlocks in stdout / stderr io
* Ensure `init.every` tasks stop when the lua instance is destroyed
* Allow fractional seconds for `init.sleep` and `init.every`
* Refresh the existing lua scripts
* Update Dockerfile build and run steps
* Add GitHub workflow to publish new versions
* Bump to v1.2.0